### PR TITLE
Ensure percent encoded parameters work

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,6 +7,7 @@ EXIT_CODE=0
 echo "Checking domains in config return 200s"
 URLS=(
   "https://lts.lehigh.edu"
+  "https%3A%2F%2Flts.lehigh.edu"
   "https://preserve.lehigh.edu"
   "https://$RANDOM.lib.lehigh.edu"
   "https://$RANDOM.$RANDOM.lib.lehigh.edu"


### PR DESCRIPTION
Per https://github.com/vufind-org/vufind/pull/3199#discussion_r1387138112, make sure we have test coverage for percent encoded URLs